### PR TITLE
Update swordappclient.php to solve first-letter truncation of uploaded package filenames

### DIFF
--- a/swordappclient.php
+++ b/swordappclient.php
@@ -82,7 +82,7 @@ class SWORDAPPClient {
         } else {
             $sac_fname_trimmed = $sac_fname;
         }
-        array_push($headers, "Content-Disposition: filename=" . $sac_fname_trimmed);
+        array_push($headers, "Content-Disposition: attachment; filename=" . $sac_fname_trimmed);
         curl_setopt($sac_curl, CURLOPT_READDATA, fopen($sac_fname, 'rb'));
         curl_setopt($sac_curl, CURLOPT_HTTPHEADER, $headers);
 
@@ -282,7 +282,7 @@ class SWORDAPPClient {
         } else {
             $sac_fname_trimmed = $sac_fname;
         }
-        array_push($headers, "Content-Disposition: filename=" . $sac_fname_trimmed);
+        array_push($headers, "Content-Disposition: attachment; filename=" . $sac_fname_trimmed);
         curl_setopt($sac_curl, CURLOPT_INFILE, fopen($sac_fname, 'rb'));
         curl_setopt($sac_curl, CURLOPT_INFILESIZE, filesize($sac_fname));
         curl_setopt($sac_curl, CURLOPT_HTTPHEADER, $headers);
@@ -344,7 +344,7 @@ class SWORDAPPClient {
         } else {
             $sac_fname_trimmed = $sac_fname;
         }
-        array_push($headers, "Content-Disposition: filename=" . $sac_fname_trimmed);
+        array_push($headers, "Content-Disposition: attachment; filename=" . $sac_fname_trimmed);
         
         curl_setopt($sac_curl, CURLOPT_READDATA, fopen($sac_fname, 'rb'));
         curl_setopt($sac_curl, CURLOPT_HTTPHEADER, $headers);


### PR DESCRIPTION
Hi - I've added "attachment;" to Content-Disposition in three places in swordappclient.php. In the deposit() function, this solves the problem of the package filename having its first letter missing (mentioned in http://sourceforge.net/mailarchive/message.php?msg_id=29147892, for example). I haven't tested the other two places where I've added it.
It's possible this is really a bug in the SWORD server code: the SWORD 2.0 Profile does not require "attachment;" for a METSDSpaceSIP package (although the example at http://swordapp.github.com/SWORDv2-Profile/SWORDProfile.html#protocoloperations_creatingresource_binary includes it). Fixing it here works, though, and the other client code I've looked at includes "attachment;".
This is my first use of GitHub and my first pull request; if there's a better way to submit this, please let me know. Thanks!
