### PR TITLE
Clean copyrightholder

### DIFF
--- a/packager_mets_swap.php
+++ b/packager_mets_swap.php
@@ -124,7 +124,7 @@ class PackagerMetsSwap {
     }
 
     function setCopyrightHolder($sac_thecopyrightholder) {
-        $this->sac_copyrightholder = $sac_thecopyrightholder;
+        $this->sac_copyrightholder = $this->clean($sac_thecopyrightholder);
     }
     
     function setCustodian($sac_thecustodian) {


### PR DESCRIPTION
We just ran into a bug where an ampersand in the copyrightholder broke mets.xml, so I added clean() to it; there are a few other uncleaned variables nearby, but I hesitated to make any further changes without cause.
