### PR TITLE
Fix array offset access syntax in php 8

### DIFF
--- a/utils.php
+++ b/utils.php
@@ -57,7 +57,7 @@
 
                 $cache = base64_decode($b64);
             } else {
-                if (!$eof && $b64{75} == '=') {
+                if (!$eof && $b64[75] == '=') {
                    $cache = $row;
                 } else {
                     $put = $b64."\r\n";


### PR DESCRIPTION
Changes the way to access indexes in arrays. Braces are not supported in newer versions of PHP.

Related Issue: #22