### PR TITLE
Using class namespaces to avoid classname clashed in OJS

### DIFF
--- a/collection.php
+++ b/collection.php
@@ -3,7 +3,7 @@ namespace SwordApp;
 require_once("utils.php");
 
 class Collection {
-
+	
 	// The title of the collection
 	public $sac_colltitle;
 

--- a/collection.php
+++ b/collection.php
@@ -1,8 +1,8 @@
 <?php
-
+namespace SwordApp;
 require_once("utils.php");
 
-class SacCollection {
+class Collection {
 
 	// The title of the collection
 	public $sac_colltitle;

--- a/collection.php
+++ b/collection.php
@@ -3,7 +3,7 @@ namespace SwordApp;
 require_once("utils.php");
 
 class Collection {
-	
+
 	// The title of the collection
 	public $sac_colltitle;
 
@@ -38,8 +38,8 @@ class Collection {
 
 		// Create the accepts arrays
 		$sac_accept = array();
-        $sac_acceptalternative = array();
-        $sac_acceptpackaging = array();
+		$sac_acceptalternative = array();
+		$sac_acceptpackaging = array();
 	}
 
 	// Add a new supported packaging type

--- a/saccollection.php
+++ b/saccollection.php
@@ -2,8 +2,8 @@
 
 require_once("utils.php");
 
-class Collection {
-	
+class SacCollection {
+
 	// The title of the collection
 	public $sac_colltitle;
 
@@ -30,7 +30,7 @@ class Collection {
 
 	// A nested service document
 	public $sac_service;
-	
+
 	// Construct a new collection by passing in a title
 	function __construct($sac_newcolltitle) {
 		// Store the title

--- a/workspace.php
+++ b/workspace.php
@@ -29,17 +29,17 @@ class Workspace {
 			$sac_newcollection->sac_href = $href[0]['href'];
 
 			// An array of the accepted deposit types
-		    foreach ($sac_collection->accept as $sac_accept) {
-                if ($sac_accept->attributes()->alternate == 'multipart-related') {
-                    $sac_newcollection->sac_acceptalternative[] = $sac_accept;
-                } else {
-                    $sac_newcollection->sac_accept[] = $sac_accept;
-                }
-            }
+			foreach ($sac_collection->accept as $sac_accept) {
+				if ($sac_accept->attributes()->alternate == 'multipart-related') {
+					$sac_newcollection->sac_acceptalternative[] = $sac_accept;
+				} else {
+					$sac_newcollection->sac_accept[] = $sac_accept;
+				}
+			}
 
 			// An array of the accepted packages
 			$sac_collection->registerXPathNamespace('sword', 'http://purl.org/net/sword/terms/');
-            foreach ($sac_collection->xpath("sword:acceptPackaging") as $sac_acceptpackaging) {
+			foreach ($sac_collection->xpath("sword:acceptPackaging") as $sac_acceptpackaging) {
 				$sac_newcollection->addAcceptPackaging($sac_acceptpackaging[0]);
 			}
 

--- a/workspace.php
+++ b/workspace.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('collection.php');
+require_once('saccollection.php');
 require_once("utils.php");
 
 class Workspace {
@@ -22,8 +22,8 @@ class Workspace {
 		// Build the collections
 		foreach ($sac_colls as $sac_collection) {
 			// Create the new collection object
-			$sac_newcollection = new Collection(sac_clean($sac_collection->children($sac_ns['atom'])->title));
-			
+			$sac_newcollection = new SacCollection(sac_clean($sac_collection->children($sac_ns['atom'])->title));
+
 			// The location of the service document
 			$href = $sac_collection->xpath("@href");
 			$sac_newcollection->sac_href = $href[0]['href'];

--- a/workspace.php
+++ b/workspace.php
@@ -1,10 +1,10 @@
 <?php
 
-require_once('saccollection.php');
+use SwordApp\Collection;
 require_once("utils.php");
 
 class Workspace {
-	
+
 	// The title of the workspace
 	public $sac_workspacetitle;
 
@@ -22,12 +22,12 @@ class Workspace {
 		// Build the collections
 		foreach ($sac_colls as $sac_collection) {
 			// Create the new collection object
-			$sac_newcollection = new SacCollection(sac_clean($sac_collection->children($sac_ns['atom'])->title));
+			$sac_newcollection = new Collection(sac_clean($sac_collection->children($sac_ns['atom'])->title));
 
 			// The location of the service document
 			$href = $sac_collection->xpath("@href");
 			$sac_newcollection->sac_href = $href[0]['href'];
-			
+
 			// An array of the accepted deposit types
 		    foreach ($sac_collection->accept as $sac_accept) {
                 if ($sac_accept->attributes()->alternate == 'multipart-related') {
@@ -36,7 +36,7 @@ class Workspace {
                     $sac_newcollection->sac_accept[] = $sac_accept;
                 }
             }
-            
+
 			// An array of the accepted packages
 			$sac_collection->registerXPathNamespace('sword', 'http://purl.org/net/sword/terms/');
             foreach ($sac_collection->xpath("sword:acceptPackaging") as $sac_acceptpackaging) {
@@ -45,7 +45,7 @@ class Workspace {
 
 			// Add the collection policy
 			$sac_newcollection->sac_collpolicy = sac_clean($sac_collection->children($sac_ns['sword'])->collectionPolicy);
-			
+
 			// Add the collection abstract
 			// Check if dcterms is in the known namespaces. If not, might not be an abstract
 			if (array_key_exists('dcterms', $sac_ns)) {
@@ -58,7 +58,7 @@ class Workspace {
 			} else {
 				$sac_newcollection->sac_mediation = false;
 			}
-			
+
 			// Add a nested service document if there is one
 			$sac_newcollection->sac_service = sac_clean($sac_collection->children($sac_ns['sword'])->service);
 


### PR DESCRIPTION
The classname `Collection` is already declared in OJS. By declaring the class with a namespace and using it as such we avoid classname clashes