### PR TITLE
Namespacing Collection class to avoid classname clash with OJS

### DIFF
--- a/collection.php
+++ b/collection.php
@@ -1,4 +1,5 @@
 <?php
+namespace SwordApp;
 
 require_once("utils.php");
 

--- a/workspace.php
+++ b/workspace.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once('collection.php');
+use SwordApp\Collection;
 require_once("utils.php");
 
 class Workspace {


### PR DESCRIPTION
@richard-jones  @stuartlewis The class Collection now has a namespace to avoid a clash with a previously declared clash in OJS.

https://github.com/swordapp/swordappv2-php-library/issues/26